### PR TITLE
Support different addon versions in `solve_solvent`

### DIFF
--- a/chemistry/sqd_pcm/requirements.txt
+++ b/chemistry/sqd_pcm/requirements.txt
@@ -1,5 +1,5 @@
 # qiskit ecosystem (implicit qiskit dependency)
-qiskit_addon_sqd~=0.10.0
+qiskit_addon_sqd~=0.11.0
 qiskit-serverless
 qiskit-ibm-runtime
 

--- a/chemistry/sqd_pcm/source_files/solve_solvent.py
+++ b/chemistry/sqd_pcm/source_files/solve_solvent.py
@@ -29,7 +29,7 @@ from qiskit_addon_sqd.fermion import (
     bitstring_matrix_to_ci_strs,
     _check_ci_strs,
 )
-from qiskit_addon_sqd import __version__ as addon_version
+from importlib_metadata import version
 
 # DSK Below is the modified CASCI kernel compatible with SQD.
 # It utilizes the "fci.selected_ci.kernel_fixed_space"
@@ -342,7 +342,7 @@ def solve_solvent(
     # have its _strs field populated with alpha and beta strings.
     assert isinstance(sci_vec._strs[0], np.ndarray) and isinstance(sci_vec._strs[1], np.ndarray)
     assert sci_vec.shape == (len(sci_vec._strs[0]), len(sci_vec._strs[1]))
-    if int(addon_version.split(".")[0]) == 0 and int(addon_version.split(".")[1]) < 11:
+    if int(vesion(qiskit_addon_sqd).split(".")[0]) == 0 and int(vesion(qiskit_addon_sqd).split(".")[1]) < 11:
         sci_state = SCIState(
             amplitudes=np.array(sci_vec),
             ci_strs_a=sci_vec._strs[0],

--- a/chemistry/sqd_pcm/source_files/solve_solvent.py
+++ b/chemistry/sqd_pcm/source_files/solve_solvent.py
@@ -342,7 +342,10 @@ def solve_solvent(
     # have its _strs field populated with alpha and beta strings.
     assert isinstance(sci_vec._strs[0], np.ndarray) and isinstance(sci_vec._strs[1], np.ndarray)
     assert sci_vec.shape == (len(sci_vec._strs[0]), len(sci_vec._strs[1]))
-    if int(vesion(qiskit_addon_sqd).split(".")[0]) == 0 and int(vesion(qiskit_addon_sqd).split(".")[1]) < 11:
+    if (
+        int(vesion(qiskit_addon_sqd).split(".")[0]) == 0
+        and int(vesion(qiskit_addon_sqd).split(".")[1]) < 11
+    ):
         sci_state = SCIState(
             amplitudes=np.array(sci_vec),
             ci_strs_a=sci_vec._strs[0],

--- a/chemistry/sqd_pcm/source_files/solve_solvent.py
+++ b/chemistry/sqd_pcm/source_files/solve_solvent.py
@@ -343,8 +343,8 @@ def solve_solvent(
     assert isinstance(sci_vec._strs[0], np.ndarray) and isinstance(sci_vec._strs[1], np.ndarray)
     assert sci_vec.shape == (len(sci_vec._strs[0]), len(sci_vec._strs[1]))
     if (
-        int(vesion(qiskit_addon_sqd).split(".")[0]) == 0
-        and int(vesion(qiskit_addon_sqd).split(".")[1]) < 11
+        int(version("qiskit_addon_sqd").split(".")[0]) == 0
+        and int(version("qiskit_addon_sqd").split(".")[1]) < 11
     ):
         sci_state = SCIState(
             amplitudes=np.array(sci_vec),

--- a/chemistry/sqd_pcm/source_files/solve_solvent.py
+++ b/chemistry/sqd_pcm/source_files/solve_solvent.py
@@ -29,6 +29,7 @@ from qiskit_addon_sqd.fermion import (
     bitstring_matrix_to_ci_strs,
     _check_ci_strs,
 )
+from qiskit_addon_sqd import __version__ as addon_version
 
 # DSK Below is the modified CASCI kernel compatible with SQD.
 # It utilizes the "fci.selected_ci.kernel_fixed_space"
@@ -341,10 +342,19 @@ def solve_solvent(
     # have its _strs field populated with alpha and beta strings.
     assert isinstance(sci_vec._strs[0], np.ndarray) and isinstance(sci_vec._strs[1], np.ndarray)
     assert sci_vec.shape == (len(sci_vec._strs[0]), len(sci_vec._strs[1]))
-    sci_state = SCIState(
-        amplitudes=np.array(sci_vec),
-        ci_strs_a=sci_vec._strs[0],
-        ci_strs_b=sci_vec._strs[1],
-    )
+    if int(addon_version.split(".")[0]) == 0 and int(addon_version.split(".")[1]) < 11:
+        sci_state = SCIState(
+            amplitudes=np.array(sci_vec),
+            ci_strs_a=sci_vec._strs[0],
+            ci_strs_b=sci_vec._strs[1],
+        )
+    else:
+        sci_state = SCIState(
+            amplitudes=np.array(sci_vec),
+            ci_strs_a=sci_vec._strs[0],
+            ci_strs_b=sci_vec._strs[1],
+            norb=num_orbitals,
+            nelec=(num_up, num_dn),
+        )
 
     return e_sci, sci_state, avg_occupancy, spin_squared, g_solv


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

-->

### Summary
This PR adds an sqd addon version check to support different versions, which allows to support both `qiskit_sqd_addon` `0.10.x` and `0.11.x`. It also bumps the addon version in the requirements.txt file.


### Details and comments


