### PR TITLE
Update templates with latest best practices

### DIFF
--- a/.github/workflows/run-sqd-pcm.yml
+++ b/.github/workflows/run-sqd-pcm.yml
@@ -22,3 +22,4 @@ jobs:
     uses: ./.github/workflows/_unit-tests.yml
     with:
       dir: chemistry/sqd_pcm
+      os-list: '["ubuntu-latest"]'

--- a/base_templates/application_function_template.py
+++ b/base_templates/application_function_template.py
@@ -12,11 +12,9 @@
 """
 Application Function Template source code.
 """
-import os
 from typing import Any
 
 import json
-import logging
 import time
 import traceback
 
@@ -26,12 +24,18 @@ from qiskit import QuantumCircuit
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.transpiler import generate_preset_pass_manager
 
-from qiskit_ibm_runtime import QiskitRuntimeService
 from qiskit_ibm_runtime import EstimatorV2
 
-from qiskit_serverless import get_arguments, save_result, update_status, Job
+from qiskit_serverless import (
+    get_arguments,
+    save_result,
+    update_status,
+    Job,
+    get_runtime_service,
+    get_logger,
+)
 
-logger = logging.getLogger(__name__)
+logger = get_logger()
 
 
 def run_function(
@@ -93,13 +97,9 @@ def run_function(
     if testing_backend is None:
         # Initialize Qiskit Runtime Service
         logger.info("Starting runtime service")
-        service = QiskitRuntimeService(
-            channel=os.environ["QISKIT_IBM_CHANNEL"],
-            instance=os.environ["QISKIT_IBM_INSTANCE"],
-            token=os.environ["QISKIT_IBM_TOKEN"],
-        )
+        service = get_runtime_service()
         backend = service.backend(backend_name)
-        logger.info("backend", backend)
+        logger.info(f"Backend: {backend.name}")
     else:
         backend = testing_backend
 
@@ -250,30 +250,11 @@ def run_function(
     return output
 
 
-def set_up_logger(my_logger: logging.Logger, level: int = logging.INFO) -> None:
-    """Logger setup to communicate logs through serverless."""
-
-    log_fmt = "%(module)s.%(funcName)s:%(levelname)s:%(asctime)s: %(message)s"
-    formatter = logging.Formatter(log_fmt)
-
-    # Set propagate to `False` since handlers are to be attached.
-    my_logger.propagate = False
-
-    stream_handler = logging.StreamHandler()
-    stream_handler.setFormatter(formatter)
-    my_logger.addHandler(stream_handler)
-    my_logger.setLevel(level)
-
-
 # This is the section where `run_function` is called, it's boilerplate code and can be used
 # without customization.
 if __name__ == "__main__":
     # Use serverless helper function to extract input arguments,
     input_args = get_arguments()
-
-    # Allow to configure logging level
-    logging_level = input_args.get("logging_level", logging.INFO)
-    set_up_logger(logger, logging_level)
 
     try:
         func_result = run_function(**input_args)

--- a/base_templates/circuit_function_template.py
+++ b/base_templates/circuit_function_template.py
@@ -15,8 +15,6 @@ Circuit Function Template source code.
 from __future__ import annotations
 
 from collections.abc import Iterable
-import logging
-import os
 import traceback
 
 import numpy as np
@@ -25,12 +23,19 @@ from qiskit.primitives.containers import EstimatorPubLike, PrimitiveResult
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit.transpiler import generate_preset_pass_manager
 
-from qiskit_ibm_runtime import QiskitRuntimeService, EstimatorV2
+from qiskit_ibm_runtime import EstimatorV2
 from qiskit_ibm_runtime.runtime_job_v2 import RuntimeJobV2
 
-from qiskit_serverless import get_arguments, save_result, update_status, Job
+from qiskit_serverless import (
+    get_arguments,
+    save_result,
+    update_status,
+    Job,
+    get_runtime_service,
+    get_logger,
+)
 
-logger = logging.getLogger(__name__)
+logger = get_logger()
 
 
 class CircuitFunction:
@@ -76,16 +81,8 @@ class CircuitFunction:
         # Validate and set input backend
         if not backend_name:
             raise ValueError(f"Invalid backend_name value {backend_name}.")
-        if os.environ.get("LOCAL_TESTING", "false").lower() == "true":
-            self._service = QiskitRuntimeService(channel="local")
-            self._backend = self._service.backend(backend_name)
-        else:
-            self._service = QiskitRuntimeService(
-                channel=os.environ["QISKIT_IBM_CHANNEL"],
-                instance=os.environ["QISKIT_IBM_INSTANCE"],
-                token=os.environ["QISKIT_IBM_TOKEN"],
-            )
-            self._backend = self._service.backend(backend_name)
+        service = get_runtime_service()
+        self._backend = service.backend(backend_name)
 
     def _set_options(self, options: dict | None = None) -> None:
         """Set options from the input."""
@@ -145,30 +142,11 @@ class CircuitFunction:
         return job.result()
 
 
-def set_up_logger(my_logger: logging.Logger, level: int = logging.INFO) -> None:
-    """Logger setup to communicate logs through serverless."""
-
-    log_fmt = "%(module)s.%(funcName)s:%(levelname)s:%(asctime)s: %(message)s"
-    formatter = logging.Formatter(log_fmt)
-
-    # Set propagate to `False` since handlers are to be attached.
-    my_logger.propagate = False
-
-    stream_handler = logging.StreamHandler()
-    stream_handler.setFormatter(formatter)
-    my_logger.addHandler(stream_handler)
-    my_logger.setLevel(level)
-
-
 # This is the section where `CircuitFunction` is initialized and ran, it's
 # boilerplate code and can be used without customization.
 if __name__ == "__main__":
     # Use serverless helper function to extract input arguments,
     input_args = get_arguments()
-
-    # Allow to configure logging level
-    logging_level = input_args.get("logging_level", logging.INFO)
-    set_up_logger(logger, logging_level)
 
     try:
         func = CircuitFunction(**input_args)

--- a/base_templates/circuit_function_template.py
+++ b/base_templates/circuit_function_template.py
@@ -15,11 +15,12 @@ Circuit Function Template source code.
 from __future__ import annotations
 
 from collections.abc import Iterable
+import time
 import traceback
 
 import numpy as np
 
-from qiskit.primitives.containers import EstimatorPubLike, PrimitiveResult
+from qiskit.primitives.containers import EstimatorPubLike
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit.transpiler import generate_preset_pass_manager
 
@@ -91,7 +92,7 @@ class CircuitFunction:
         self._execution_options = options.get("execution_options", None)
         # Here, additional options such as error mitigation options could be set
 
-    def run(self) -> PrimitiveResult:
+    def run(self) -> dict:
         """Execute the request."""
 
         # The circuit function encapsulates steps 2-4 of the Qiskit Pattern workflow:
@@ -100,6 +101,7 @@ class CircuitFunction:
         # --
         # Step 2: Optimize
         # Transpile PUBs (circuits and observables) to match ISA
+        start_optimizing = time.time()
         # Report sub-status
         update_status(Job.OPTIMIZING_HARDWARE)
 
@@ -121,12 +123,15 @@ class CircuitFunction:
             isa_pub = (isa_circ, isa_observables, params, pub.precision)
             isa_pubs.append(EstimatorPub.coerce(isa_pub))
 
+        end_optimizing = time.time()
+
         # --
         # Step 3: Execute on Hardware
         # Initialize EstimatorV2
         estimator = EstimatorV2(mode=self._backend, options=self._execution_options)
 
         # Run
+        start_waiting_qpu = time.time()
         job = estimator.run(pubs=isa_pubs)
         self._jobs.append(job)
         logger.info("Qiskit Runtime job %s submitted.", job.job_id())
@@ -135,11 +140,45 @@ class CircuitFunction:
         while job.status() == "QUEUED":
             update_status(Job.WAITING_QPU)
 
+        end_waiting_qpu = time.time()
         update_status(Job.EXECUTING_QPU)
+
+        # Wait until job is complete
+        hw_results = job.result()
+        end_executing_qpu = time.time()
+
+        # --
+        # Step 4: Post-process
         # In this case, the result is returned directly without post-processing,
         # but additional post-processing could be performed at this step
         # (Step 4 of the Qiskit Pattern)
-        return job.result()
+        start_pp = time.time()
+        update_status(Job.POST_PROCESSING)
+        end_pp = time.time()
+
+        metadata = {
+            "resources_usage": {
+                "RUNNING: OPTIMIZING_FOR_HARDWARE": {
+                    "CPU_TIME": end_optimizing - start_optimizing,
+                },
+                "RUNNING: WAITING_FOR_QPU": {
+                    "CPU_TIME": end_waiting_qpu - start_waiting_qpu,
+                },
+                "RUNNING: EXECUTING_QPU": {
+                    "QPU_TIME": end_executing_qpu - end_waiting_qpu,
+                },
+                "RUNNING: POST_PROCESSING": {
+                    "CPU_TIME": end_pp - start_pp,
+                },
+            },
+        }
+
+        output = {
+            "hw_results": hw_results,
+            "metadata": metadata,
+        }
+
+        return output
 
 
 # This is the section where `CircuitFunction` is initialized and ran, it's

--- a/chemistry/sqd_pcm/source_files/sqd_pcm_entrypoint.py
+++ b/chemistry/sqd_pcm/source_files/sqd_pcm_entrypoint.py
@@ -19,7 +19,6 @@ from datetime import datetime
 import os
 import sys
 import json
-import logging
 import time
 import traceback
 import numpy as np
@@ -49,13 +48,14 @@ from qiskit_serverless import (
     update_status,
     Job,
     get_runtime_service,
+    get_logger,
 )
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, current_dir)
 from solve_solvent import solve_solvent  # pylint: disable=wrong-import-position
 
-logger = logging.getLogger(__name__)
+logger = get_logger()
 
 
 def run_function(
@@ -551,31 +551,12 @@ def run_function(
     return output
 
 
-def set_up_logger(my_logger: logging.Logger, level: int = logging.INFO) -> None:
-    """Logger setup to communicate logs through serverless."""
-
-    log_fmt = "%(module)s.%(funcName)s:%(levelname)s:%(asctime)s: %(message)s"
-    formatter = logging.Formatter(log_fmt)
-
-    # Set propagate to `False` since handlers are to be attached.
-    my_logger.propagate = False
-
-    stream_handler = logging.StreamHandler()
-    stream_handler.setFormatter(formatter)
-    my_logger.addHandler(stream_handler)
-    my_logger.setLevel(level)
-
-
 # This is the section where `run_function` is called, it's boilerplate code and can be used
 # without customization.
 if __name__ == "__main__":
 
     # Use serverless helper function to extract input arguments,
     input_args = get_arguments()
-
-    # Allow to configure logging level
-    logging_level = input_args.get("logging_level", logging.INFO)
-    set_up_logger(logger, logging_level)
 
     try:
         func_result = run_function(**input_args)

--- a/physics/hamiltonian_simulation/source_files/hamiltonian_sim_entrypoint.py
+++ b/physics/hamiltonian_simulation/source_files/hamiltonian_sim_entrypoint.py
@@ -17,7 +17,6 @@ Hamiltonian Simulation Function Template source code.
 import os
 import datetime
 import json
-import logging
 import time
 import traceback
 import numpy as np
@@ -41,13 +40,20 @@ from qiskit_addon_aqc_tensor.objective import OneMinusFidelity
 
 from qiskit_ibm_runtime import EstimatorV2 as Estimator
 
-from qiskit_serverless import get_arguments, save_result, update_status, Job, get_runtime_service
+from qiskit_serverless import (
+    get_arguments,
+    save_result,
+    update_status,
+    Job,
+    get_runtime_service,
+    get_logger,
+)
 
 # this variable is required to import quimb.tensor
 os.environ["NUMBA_CACHE_DIR"] = "/data"
 import quimb.tensor  # pylint: disable=wrong-import-position
 
-logger = logging.getLogger(__name__)
+logger = get_logger()
 
 
 def run_function(
@@ -335,30 +341,11 @@ def run_function(
     return output
 
 
-def set_up_logger(my_logger: logging.Logger, level: int = logging.INFO) -> None:
-    """Logger setup to communicate logs through serverless."""
-
-    log_fmt = "%(module)s.%(funcName)s:%(levelname)s:%(asctime)s: %(message)s"
-    formatter = logging.Formatter(log_fmt)
-
-    # Set propagate to `False` since handlers are to be attached.
-    my_logger.propagate = False
-
-    stream_handler = logging.StreamHandler()
-    stream_handler.setFormatter(formatter)
-    my_logger.addHandler(stream_handler)
-    my_logger.setLevel(level)
-
-
 # This is the section where `run_function` is called, it's boilerplate code and can be used
 # without customization.
 if __name__ == "__main__":
     # Use serverless helper function to extract input arguments,
     input_args = get_arguments()
-
-    # Allow to configure logging level
-    logging_level = input_args.get("logging_level", logging.INFO)
-    set_up_logger(logger, logging_level)
 
     try:
         func_result = run_function(**input_args)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

-->

### Summary
This PR updates all function templates and entrypoints to follow the latest best practices from https://qiskit.github.io/qiskit-serverless/release-notes.html. Main changes are:

- use the new get_runtime_service() 
- get_logger() helper functions from qiskit_serverless, replacing the previous manual setup patterns. 
- always return usage metadata

🔧 solves #30 

### Details and comments
Previously, each template manually instantiated QiskitRuntimeService by reading environment variables (QISKIT_IBM_CHANNEL, QISKIT_IBM_INSTANCE, QISKIT_IBM_TOKEN) and included a boilerplate set_up_logger function to configure logging with custom formatters and stream handlers.  This duplicated logic across every template and required users to manage environment variables directly.

By adopting get_runtime_service() and get_logger(), we delegate service initialization and logging configuration to qiskit_serverless, which handles credentials and logging setup internally. This simplifies the templates significantly, removes redundant code (~70 lines across the four files), and ensures that all templates follow a consistent, maintainable pattern. It also means that any future improvements to service initialization or logging in qiskit_serverless will automatically benefit all templates without requiring individual updates.

Finally, The circuit_function_template.py has been updated to return a structured output dictionary instead of the raw PrimitiveResult. The run() method now tracks CPU and QPU time across each stage of the Qiskit Pattern (optimizing, waiting for QPU, executing on QPU, and post-processing) and returns a dict containing the hardware results under hw_results and a metadata field with resources_usage timing breakdowns, consistent with the structure used in the other templates like sqd_pcm_entrypoint.py. 
