### PR TITLE
Fix resource usage metadata datatypes in application function templates.

### DIFF
--- a/base_templates/application_function_template.py
+++ b/base_templates/application_function_template.py
@@ -232,21 +232,15 @@ def run_function(
     # Return expectation values in serializable format
     logger.info("Hardware expectation values", hw_expvals)
     output["hw_expvals"] = hw_expvals[0]
-    output["metadata"]["resources_usage"]["RUNNING: WAITING_FOR_QPU"] = (
-        {
-            "CPU_TIME": end_waiting_qpu - start_waiting_qpu,
-        },
-    )
-    output["metadata"]["resources_usage"]["RUNNING: EXECUTING_QPU"] = (
-        {
-            "CPU_TIME": end_executing_qpu - end_waiting_qpu,
-        },
-    )
-    output["metadata"]["resources_usage"]["RUNNING: POST_PROCESSING"] = (
-        {
-            "CPU_TIME": end_pp - start_pp,
-        },
-    )
+    output["metadata"]["resources_usage"]["RUNNING: WAITING_FOR_QPU"] = {
+        "CPU_TIME": end_waiting_qpu - start_waiting_qpu,
+    }
+    output["metadata"]["resources_usage"]["RUNNING: EXECUTING_QPU"] = {
+        "CPU_TIME": end_executing_qpu - end_waiting_qpu,
+    }
+    output["metadata"]["resources_usage"]["RUNNING: POST_PROCESSING"] = {
+        "CPU_TIME": end_pp - start_pp,
+    }
     return output
 
 

--- a/physics/hamiltonian_simulation/source_files/hamiltonian_sim_entrypoint.py
+++ b/physics/hamiltonian_simulation/source_files/hamiltonian_sim_entrypoint.py
@@ -323,21 +323,15 @@ def run_function(
     # Return expectation values in serializable format
     logger.info(f"Hardware expectation values: {hw_expvals}")
     output["hw_expvals"] = hw_expvals[0]
-    output["metadata"]["resources_usage"]["RUNNING: WAITING_FOR_QPU"] = (
-        {
-            "CPU_TIME": end_waiting_qpu - start_waiting_qpu,
-        },
-    )
-    output["metadata"]["resources_usage"]["RUNNING: EXECUTING_QPU"] = (
-        {
-            "QPU_TIME": end_executing_qpu - end_waiting_qpu,
-        },
-    )
-    output["metadata"]["resources_usage"]["RUNNING: POST_PROCESSING"] = (
-        {
-            "CPU_TIME": end_pp - start_pp,
-        },
-    )
+    output["metadata"]["resources_usage"]["RUNNING: WAITING_FOR_QPU"] = {
+        "CPU_TIME": end_waiting_qpu - start_waiting_qpu,
+    }
+    output["metadata"]["resources_usage"]["RUNNING: EXECUTING_QPU"] = {
+        "CPU_TIME": end_executing_qpu - end_waiting_qpu,
+    }
+    output["metadata"]["resources_usage"]["RUNNING: POST_PROCESSING"] = {
+        "CPU_TIME": end_pp - start_pp,
+    }
     return output
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

-->

### Summary
The application function base template (`base_templates/application_function_template.py`) and template implementation for Hamiltonian simulation (`physics/hamiltonian_simulation/source_files/hamiltonian_sim_entrypoint.py`) initially use nested dictionaries for `CPU`/`QPU_TIME`s in the `output` metadata dictionary for resource usage (for the mapping & optimization steps), however use a dictionary within a tuple for the remainder of the resource usages. I believe that this may have been unintentional (since `circuit_function_template.py` uses a consistent nested dictionary for all resources in the output metadata), and replaced them with simple nested dictionaries.

### Details and comments
The tuple encapsulation of the `CPU_TIME` dictionaries by means of `( "key":value , )` were replaced by vanilla nested dictionaries in `application_function_template.py` and `hamiltonian_sim_entrypoint.py`.

